### PR TITLE
Changed bg switch logic for vim

### DIFF
--- a/local/bin/toggle-theme
+++ b/local/bin/toggle-theme
@@ -12,12 +12,11 @@ CURRENT_MODE=$(gsettings get org.gnome.desktop.interface color-scheme)
 
 # Function to switch theme in n(v)im panes inside tmux
 switch_vim_theme() {
-  theme_for_vim_panes="$1"
   tmux list-panes -a -F '#{pane_id} #{pane_current_command}' |
     grep vim | # this captures vim and nvim
     cut -d ' ' -f 1 |
     xargs -I PANE tmux send-keys -t PANE ESCAPE \
-      ":set background=${theme_for_vim_panes}" ENTER
+      ':source $MYVIMRC' ENTER
 }
 
 # Toggle logic based on current mode
@@ -25,12 +24,12 @@ if [ "$CURRENT_MODE" = "'prefer-dark'" ]; then
   gsettings set org.gnome.desktop.interface color-scheme 'prefer-light'
   sed -i "s/${DARKTHEME}/${LIGHTTHEME}/" "$ALACRITTYCONF" "$TMUXCONF"
   sed -i 's/dark/light/' "$VIMCONF"
-  switch_vim_theme "light"
+  switch_vim_theme
 else
   gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
   sed -i "s/${LIGHTTHEME}/${DARKTHEME}/" "$ALACRITTYCONF" "$TMUXCONF"
   sed -i 's/light/dark/' "$VIMCONF"
-  switch_vim_theme "dark"
+  switch_vim_theme
 fi
 
 tmux source-file "$TMUXCONF"


### PR DESCRIPTION
* Instead of setting the background to light/dark in each vim pane, source the vimrc after making the changes in that file
* This works better because sometimes syntax highlighting groups break when the bg is reset